### PR TITLE
Remove "brew update" from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
       # workaround for https://github.com/travis-ci/travis-ci/issues/2312
       language: generic
       before_install:
-        - brew update
         - brew install python3
         - virtualenv env -p python3
         - source env/bin/activate


### PR DESCRIPTION
This takes ~5 minutes, the default builder should already have the python package version we need.